### PR TITLE
移除zotero file 插件，原因：不维护

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -342,16 +342,6 @@ export const plugins: PluginInfo[] = [
     ],
   },
   {
-    name: "Zotero File",
-    repo: "MuiseDestiny/zotero-file",
-    releases: [
-      {
-        targetZoteroVersion: "7",
-        tagName: "latest",
-      },
-    ],
-  },
-  {
     name: "Zotero Format Metadata",
     repo: "northword/zotero-format-metadata",
     releases: [


### PR DESCRIPTION
Zotero File 插件，因官方已有相似功能，要删库不维护了