### PR TITLE
修改`kgithub`地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ npm run get-chart
 
 - GitHub 代理：<https://github.com/hunshcn/gh-proxy>
 - JsDeliver：<https://www.jsdelivr.com/>
-- KGitHub: <https://help.kgithub.com/>
+- KGitHub: <https://help.kkgithub.com/>
 
 本项目是对 [l0o0/ZoteroPlugins](https://github.com/l0o0/ZoteroPlugins) 的 Typescript 重新实现。
 

--- a/src/get_plugins_info.ts
+++ b/src/get_plugins_info.ts
@@ -141,7 +141,7 @@ export async function progressPlugins(plugins: PluginInfo[]) {
           jsdeliver: `https://cdn.jsdelivr.net/gh/northword/zotero-plugins@gh-pages/dist/xpi/${release.assetId}.xpi`,
           kgithub: asset.browser_download_url.replace(
             "github.com",
-            "kgithub.com"
+            "kkgithub.com"
           ),
         };
       });


### PR DESCRIPTION
close #29 

CC @syt2 

个人看法：我觉得插件合集插件里可以保持现状（不放kgithub），因为这个镜像站只支持国内ip访问，这可能导致插件无法收到预期的数据（用户可能并不会注意到网络这一点）。