### PR TITLE
修改自动提交的身份为GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,8 @@ jobs:
           branch: gh-pages
           folder: docs
           single-commit: true
+          git-config-name: github-actions[bot]
+          git-config-email: github-actions[bot]@users.noreply.github.com
 
   sync-gitee:
     name: Sync to Gitee


### PR DESCRIPTION
影响 Action 向 `gh-pages` 分支提交的作者信息，从原来的上下文作者和邮箱改为 GitHub Action Bot，避免由于计划任务产生的提交污染用户的贡献热力图。