### PR TITLE
Add new plugin - zoplicate

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -543,6 +543,16 @@ export const plugins: PluginInfo[] = [
       },
     ],
   },
+  {
+    name: "Zoplicate",
+    repo: "ChenglongMa/zoplicate",
+    releases: [
+      {
+        targetZoteroVersion: "7",
+        tagName: "latest",
+      },
+    ],
+  },
 ];
 
 // 以下列表仅供开发测试使用

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -52,6 +52,7 @@ export interface PluginInfo {
 }
 
 // 贡献者贡献插件时，请按照 `name` 字母顺序排序，第一个“插件商店”插件始终置顶以方便查找。
+// Please sort the plugins in alphabetical order by `name` when contributing.
 export const plugins: PluginInfo[] = [
   {
     name: "Zotero 插件合集",
@@ -420,6 +421,16 @@ export const plugins: PluginInfo[] = [
     ],
   },
   {
+    name: "Zoplicate",
+    repo: "ChenglongMa/zoplicate",
+    releases: [
+      {
+        targetZoteroVersion: "7",
+        tagName: "latest",
+      },
+    ],
+  },
+  {
     name: "ZotCard",
     repo: "018/zotcard",
     releases: [
@@ -539,16 +550,6 @@ export const plugins: PluginInfo[] = [
     releases: [
       {
         targetZoteroVersion: "6",
-        tagName: "latest",
-      },
-    ],
-  },
-  {
-    name: "Zoplicate",
-    repo: "ChenglongMa/zoplicate",
-    releases: [
-      {
-        targetZoteroVersion: "7",
         tagName: "latest",
       },
     ],


### PR DESCRIPTION
A plugin that does one thing only: **Detect** and **Manage** duplicate items in [![zotero](https://www.zotero.org/support/lib/exe/fetch.php?tok=2735f1&media=https%3A%2F%2Fwww.zotero.org%2Fstatic%2Fimages%2Fpromote%2Fzotero-logo-128x31.png)](https://www.zotero.org/).

The plugin can detect if the newly imported item is a duplicate of an existing item in the library.
If so, it will prompt you to process the duplicate items.

The actions you can take are:

1. **Keep This**: Save the last imported item and delete the rest.
2. **Keep Others**: Delete the last imported item and save the rest.
3. **Keep All**: Keep both the new item and the existing item.
4. **Merge Manually**: Go to Duplicate Panel and merge the duplicate item manually.