### PR TITLE
fix: show addonID in each release

### DIFF
--- a/src/get_plugins_info.ts
+++ b/src/get_plugins_info.ts
@@ -12,7 +12,7 @@ export async function fetchPlugins(plugins: PluginInfo[]) {
   for (let plugin of plugins) {
     console.log(`开始处理 ${plugin.name}`);
     await fetchPlugin(plugin);
-    process.env.CI
+    !process.env.CI
       ? writeFile(
           `${dist}/plugins-debug.json`,
           JSON.stringify(plugins, null, 2)
@@ -175,7 +175,7 @@ async function fetchPlugin(plugin: PluginInfo) {
         .toString("utf8");
       const manifestData = JSON.parse(fileData);
       // plugin.id = release.id = manifestData.applications.zotero.id;
-      plugin.id = manifestData.applications.zotero.id;
+      release.id = manifestData.applications.zotero.id;
       plugin.description = plugin.description || manifestData.description || "";
       // todo: 适配多语言，当值为 `__MSG_description__` 是前往 i18n 目录获取
     } else if (zipEntryNames.includes("install.rdf")) {
@@ -195,7 +195,7 @@ async function fetchPlugin(plugin: PluginInfo) {
         (err, result) => {
           const manifestData = result; //JSON.parse(result);
           // console.log(util.inspect(result, false, null));
-          plugin.id = manifestData["RDF"]["Description"]
+          release.id = manifestData["RDF"]["Description"]
             .map((Description: any) => {
               // console.log(Description);
               if (Description["about"] == "urn:mozilla:install-manifest") {

--- a/src/get_plugins_info.ts
+++ b/src/get_plugins_info.ts
@@ -174,8 +174,8 @@ async function fetchPlugin(plugin: PluginInfo) {
         .getData()
         .toString("utf8");
       const manifestData = JSON.parse(fileData);
-      // plugin.id = release.id = manifestData.applications.zotero.id;
-      release.id = manifestData.applications.zotero.id;
+      plugin.id = release.id = manifestData.applications.zotero.id;
+      // release.id = manifestData.applications.zotero.id;
       plugin.description = plugin.description || manifestData.description || "";
       // todo: 适配多语言，当值为 `__MSG_description__` 是前往 i18n 目录获取
     } else if (zipEntryNames.includes("install.rdf")) {
@@ -195,7 +195,7 @@ async function fetchPlugin(plugin: PluginInfo) {
         (err, result) => {
           const manifestData = result; //JSON.parse(result);
           // console.log(util.inspect(result, false, null));
-          release.id = manifestData["RDF"]["Description"]
+          plugin.id = release.id = manifestData["RDF"]["Description"]
             .map((Description: any) => {
               // console.log(Description);
               if (Description["about"] == "urn:mozilla:install-manifest") {

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -28,8 +28,10 @@ export interface PluginInfo {
      * 注意 `git.tag_name` 有的有 `v` 而有的没有，可以通过发布链接来判断
      */
     tagName: "latest" | "pre" | string;
-
-    // id?: string;
+    /**
+     * 插件 ID，自 XPI 中提取
+     */
+    id?: string;
 
     currentVersion?: string;
     xpiDownloadUrl?: {
@@ -43,10 +45,8 @@ export interface PluginInfo {
     downloadCount?: number;
     assetId?: number;
   }>;
-  /**
-   * 插件 ID，自 XPI 中提取
-   */
-  id?: string;
+
+  // id?: string;
   description?: string;
   star?: number;
   watchers?: number;

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -46,7 +46,7 @@ export interface PluginInfo {
     assetId?: number;
   }>;
 
-  // id?: string;
+  id?: string;
   description?: string;
   star?: number;
   watchers?: number;


### PR DESCRIPTION
resolve: https://github.com/zotero-chinese/zotero-plugins/pull/54#issuecomment-1854943840

在这个 PR 中，每一个插件及其 `release` 都提供了 ID；等 @syt2 的插件完成更新一段时间后，只在 release 里包含 id。