### PR TITLE
get plugin version from xpi

### DIFF
--- a/src/get_plugins_info.ts
+++ b/src/get_plugins_info.ts
@@ -107,7 +107,7 @@ async function fetchPlugin(plugin: PluginInfo) {
     }
 
     await getRelease().then(async (resp) => {
-      release.currentVersion = resp.tag_name;
+      release.currentVersion = release.tagName = resp.tag_name;
 
       const asset = resp.assets
         .filter((asset) => {
@@ -176,6 +176,7 @@ async function fetchPlugin(plugin: PluginInfo) {
       const manifestData = JSON.parse(fileData);
       plugin.id = release.id = manifestData.applications.zotero.id;
       // release.id = manifestData.applications.zotero.id;
+      release.xpiVersion = manifestData.version || "";
       plugin.description = plugin.description || manifestData.description || "";
       // todo: 适配多语言，当值为 `__MSG_description__` 是前往 i18n 目录获取
     } else if (zipEntryNames.includes("install.rdf")) {
@@ -214,6 +215,12 @@ async function fetchPlugin(plugin: PluginInfo) {
             "",
             "NO desc",
           ])[1];
+      
+      release.xpiVersion = (fileData.match(/em:version="(.*?)"/) ?? 
+        fileData.match(/<em:version>(.*?)<\/em:version>/) ?? [
+          "", 
+          "",
+        ])[1];
     }
   }
 }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -26,6 +26,7 @@ export interface PluginInfo {
      * `pre`：最新预发布；
      * `string`：发布对应的 `git.tag_name`；
      * 注意 `git.tag_name` 有的有 `v` 而有的没有，可以通过发布链接来判断
+     * 程序执行后，`tagName` 将替换为实际的 `git.tag_name`
      */
     tagName: "latest" | "pre" | string;
     /**
@@ -33,6 +34,14 @@ export interface PluginInfo {
      */
     id?: string;
 
+    /**
+     * 插件版本，自 XPI 中提取
+     */
+    xpiVersion?: string;
+
+    /**
+     * @deprecated This property is deprecated and will be removed in the future. Use the tagName instead.
+     */
     currentVersion?: string;
     xpiDownloadUrl?: {
       github: string;
@@ -46,6 +55,9 @@ export interface PluginInfo {
     assetId?: number;
   }>;
 
+  /**
+   * @deprecated This property is deprecated and will be removed in the future. Use the id in releases instead.
+   */
   id?: string;
   description?: string;
   star?: number;

--- a/src/renderMarkdown.ts
+++ b/src/renderMarkdown.ts
@@ -8,12 +8,12 @@ export async function renderMarkdown(plugins: PluginInfo[]) {
     name += `![GitHub Repo stars ${plugin.star}](https://img.shields.io/github/stars/${plugin.repo})`;
     plugin.releases.forEach((release, index) => {
       if (release.assetId == undefined) {
-        console.log(`  ${plugin.name} ${release.currentVersion} 不存在`);
+        console.log(`  ${plugin.name} ${release.tagName} 不存在`);
         return;
       }
 
       // let releaseInfo = `[![适配 Zotero ${release.targetZoteroVersion}](https://img.shields.io/badge/Zotero-${release.targetZoteroVersion}-green?&logo=zotero&logoColor=CC2936)](https://www.zotero.org) </br>`;
-      // releaseInfo += `![版本 ${release.currentVersion}](https://img.shields.io/badge/版本-${release.targetZoteroVersion}-green) </br>`;
+      // releaseInfo += `![版本 ${release.tagName}](https://img.shields.io/badge/版本-${release.targetZoteroVersion}-green) </br>`;
       // releaseInfo += `![发布日期 ${new Date(release.releaseData ?? "").toLocaleString("zh-CN")}](https://img.shields.io/badge/日期-${encodeURI(new Date(release.releaseData ?? "").toLocaleString("zh-CN"))}-green) </br>`;
       // releaseInfo += `![下载量 ${release.downloadCount}](https://img.shields.io/badge/下载量-${release.downloadCount}-green)`;
       let downloadUrl = `<ul>`;
@@ -29,9 +29,9 @@ export async function renderMarkdown(plugins: PluginInfo[]) {
         !index ? plugin.description : "",
         !index ? `[${plugin.author?.name}](${plugin.author?.url})` : "",
         release.targetZoteroVersion,
-        release.currentVersion,
+        release.tagName,
         new Date(release.releaseData ?? "").toLocaleString("zh-CN") +
-          `</br>![下载量 ${release.downloadCount}](https://img.shields.io/github/downloads/${plugin.repo}/${release.currentVersion}/total?label=下载量)`,
+          `</br>![下载量 ${release.downloadCount}](https://img.shields.io/github/downloads/${plugin.repo}/${release.tagName}/total?label=下载量)`,
         // releaseInfo,
         downloadUrl,
       ];


### PR DESCRIPTION
- 废弃 `currentVersion` 属性，废弃外部 `id` 属性
- 程序运行时，将 `tagName` 属性设置为真实的GitHub仓库的tag名（即，原 `currentVersion` 字段）
- 从xpi包中提取插件版本，至release信息内的新增 `xpiVersion` 字段