### PR TITLE
revert: use stock chart

### DIFF
--- a/src/charts.ts
+++ b/src/charts.ts
@@ -471,8 +471,7 @@ export default async function getChartOptions(plugins: PluginInfo[]) {
       {
         cell: "star-history",
         type: "Highcharts",
-        // Disable stock to fix https://github.com/zotero-chinese/website/issues/6
-        // chartConstructor: "stockChart",
+        chartConstructor: "stockChart",
         chartOptions: {
           chart: { type: "spline", height: 600 },
           exporting,


### PR DESCRIPTION
This commit revert https://github.com/zotero-chinese/zotero-plugins/commit/c5c611b37ae9063ff700a0d95aec6157d973564b

ref: https://github.com/zotero-chinese/website/pull/44