### PR TITLE
Translate: temporarily restricted to version 2.0.5

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -635,7 +635,7 @@ export const plugins: PluginInfoBase[] = [
     releases: [
       {
         targetZoteroVersion: '7',
-        tagName: 'latest',
+        tagName: 'v2.0.5',
       },
       {
         targetZoteroVersion: '6',


### PR DESCRIPTION
Translate 插件 v2.0.6 由于使用了 item pane info rows api，因此限制了最低 Zotero 版本为 7.0.10，此版本尚未发布，故临时限制插件最新版为 2.0.5.

待 Zotero v7.0.10 正式发布后恢复为 `latest`.