### PR TITLE
add plugin zotero-pdf-background

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "0.0.0",
   "private": "true",
+  "packageManager": "pnpm@9.15.1",
   "description": "Zotero 插件合集",
   "author": "northword",
   "license": "MIT",

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -433,6 +433,20 @@ export const plugins: PluginInfoBase[] = [
     tags: ['ai', 'productivity'],
   },
   {
+    repo: 'q77190858/zotero-pdf-background',
+    releases: [
+      {
+        targetZoteroVersion: '7',
+        tagName: 'latest',
+      },
+      {
+        targetZoteroVersion: '6',
+        tagName: 'v0.0.2',
+      },
+    ],
+    tags: ['reader'],
+  },
+  {
     repo: 'redleafnew/delitemwithatt',
     releases: [
       {
@@ -703,20 +717,6 @@ export const plugins: PluginInfoBase[] = [
       },
     ],
     tags: ['others'],
-  },
-  {
-    repo: 'q77190858/zotero-pdf-background',
-    releases: [
-      {
-        targetZoteroVersion: '7',
-        tagName: 'latest',
-      },
-      {
-        targetZoteroVersion: '6',
-        tagName: 'v0.0.2',
-      },
-    ],
-    tags: ['reader'],
   },
 ]
 

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -704,6 +704,20 @@ export const plugins: PluginInfoBase[] = [
     ],
     tags: ['others'],
   },
+  {
+    repo: 'q77190858/zotero-pdf-background',
+    releases: [
+      {
+        targetZoteroVersion: '7',
+        tagName: 'latest',
+      },
+      {
+        targetZoteroVersion: '6',
+        tagName: 'v0.0.2',
+      },
+    ],
+    tags: ['reader'],
+  },
 ]
 
 /**


### PR DESCRIPTION
add a new zotero plugin zotero-pdf-background, which can set background color of pdf reader to care for reader's eyes.