### PR TITLE
add plugin SciImage/zotero-attachment-scanner

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -525,6 +525,16 @@ export const plugins: PluginInfoBase[] = [
     tags: ['metadata'],
   },
   {
+    repo: 'SciImage/zotero-attachment-scanner',
+    releases: [
+      {
+        targetZoteroVersion: '7',
+        tagName: 'latest',
+      },
+    ],
+    tags: ['attachment'],
+  },
+  {
     repo: 'scitedotai/scite-zotero-plugin',
     releases: [
       {


### PR DESCRIPTION
**[Attachment Scanner](https://github.com/SciImage/zotero-attachment-scanner)** is a Zotero plugin designed to scan attachments and add tags to items with no, missing, or duplicate attachments. It functions similarly to the **[Zotero Storage Scanner](https://github.com/retorquere/zotero-storage-scanner)** plugin but is compatible with Zotero v.7.0.