### PR TITLE
add Creling/Zotero-Metadata-Scraper

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -93,6 +93,16 @@ export const plugins: PluginInfoBase[] = [
       },
     ],
     tags: ['favorite', 'metadata'],
+  },  
+  {
+    repo: 'Creling/Zotero-Metadata-Scraper',
+    releases: [
+      {
+        targetZoteroVersion: '7',
+        tagName: 'latest',
+      }
+    ],
+    tags: ['metadata'],
   },
   {
     repo: 'daeh/zotero-markdb-connect',

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -93,14 +93,14 @@ export const plugins: PluginInfoBase[] = [
       },
     ],
     tags: ['favorite', 'metadata'],
-  },  
+  },
   {
     repo: 'Creling/Zotero-Metadata-Scraper',
     releases: [
       {
         targetZoteroVersion: '7',
         tagName: 'latest',
-      }
+      },
     ],
     tags: ['metadata'],
   },


### PR DESCRIPTION
Add https://github.com/Creling/Zotero-Metadata-Scraper, a Zotero plugin that automatically retrieves and updates paper metadata from multiple academic sources based on paper titles.