### PR TITLE
Add zotero-tab-limiter

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -119,6 +119,16 @@ export const plugins: PluginInfoBase[] = [
     tags: ['integration'],
   },
   {
+    repo: 'david3684/zotero-tab-limiter',
+    releases: [
+      {
+        targetZoteroVersion: '7',
+        tagName: 'latest',
+      },
+    ],
+    tags: ['others'],
+  },
+  {
     repo: 'diegodlh/zotero-cita',
     releases: [
       {
@@ -825,16 +835,6 @@ export const plugins: PluginInfoBase[] = [
     ],
     tags: ['others'],
   },
-  {
-    repo: "david3684/zotero-tab-limiter",
-    releases: [
-      {
-        targetZoteroVersion: "7",
-        tagName: "latest"
-      }
-    ],
-    tags: ['others'],
-  }
 ]
 
 /**

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -825,6 +825,16 @@ export const plugins: PluginInfoBase[] = [
     ],
     tags: ['others'],
   },
+  {
+    repo: "david3684/zotero-tab-limiter",
+    releases: [
+      {
+        targetZoteroVersion: "7",
+        tagName: "latest"
+      }
+    ],
+    tags: ['others'],
+  }
 ]
 
 /**


### PR DESCRIPTION
Add Zotero Tab Limiter plugin. This plugin personalize and sets the limit of number of open tabs in Zotero. If exceeds the limit, it automatically closes the oldest tab. Supports Zotero 7.

- repository: treblocami/zotero-tab-limiter