### PR TITLE
new plugin: minimize-zotero-to-tray

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -909,6 +909,16 @@ export const plugins: PluginInfoBase[] = [
     ],
     tags: ['others'],
   },
+  {
+    repo: 'B3000Kcn/minimize-zotero-to-tray',
+    releases: [
+      {
+        targetZoteroVersion: '7',
+        tagName: 'latest',
+      },
+    ],
+    tags: ['interface'],
+  },
 ]
 
 /**


### PR DESCRIPTION
A Zotero 7 plugin that lets you minimize Zotero to the tray, show/hide it with a single tray icon click or a global hotkey, and, if you want, automatically hide it on startup. Keep your reference manager running quietly in the background without cluttering your taskbar.