### PR TITLE
Add Zotero MCP Plugin to plugin store

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -125,6 +125,16 @@ export const plugins: PluginInfoBase[] = [
     tags: ['metadata'],
   },
   {
+    repo: 'cookjohn/zotero-mcp',
+    releases: [
+      {
+        targetZoteroVersion: '7',
+        tagName: 'latest',
+      },
+    ],
+    tags: ['integration', 'ai'],
+  },
+  {
     repo: 'daeh/zotero-citation-tally',
     releases: [
       {

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -115,16 +115,6 @@ export const plugins: PluginInfoBase[] = [
     tags: ['favorite', 'metadata'],
   },
   {
-    repo: 'Creling/Zotero-Metadata-Scraper',
-    releases: [
-      {
-        targetZoteroVersion: '7',
-        tagName: 'latest',
-      },
-    ],
-    tags: ['metadata'],
-  },
-  {
     repo: 'cookjohn/zotero-mcp',
     releases: [
       {
@@ -133,6 +123,16 @@ export const plugins: PluginInfoBase[] = [
       },
     ],
     tags: ['integration', 'ai'],
+  },
+  {
+    repo: 'Creling/Zotero-Metadata-Scraper',
+    releases: [
+      {
+        targetZoteroVersion: '7',
+        tagName: 'latest',
+      },
+    ],
+    tags: ['metadata'],
   },
   {
     repo: 'daeh/zotero-citation-tally',


### PR DESCRIPTION
## 🔌 Add Zotero MCP Plugin

  ### Plugin Information
  - **Repository**: `cookjohn/zotero-mcp`
  - **Plugin Name**: Zotero MCP Plugin
  - **Version**: v1.2.3
  - **Zotero Compatibility**: Zotero 7

  ### Description
  This plugin provides MCP (Model Context Protocol) server functionality for Zotero, enabling AI clients to access and interact with Zotero library data through a
  standardized protocol.

  ### Key Features
  - 🚀 **MCP Server**: Built-in HTTP server supporting MCP protocol
  - 🎯 **Multi-client Support**: Works with Claude Desktop, Cline, Continue.dev, Cursor, Cherry Studio, Gemini CLI, Chatbox, Trae AI, and custom HTTP clients
  - 🌐 **Bilingual UI**: Complete support for English and Chinese
  - 🔧 **Easy Configuration**: Built-in configuration generator for popular AI clients
  - 📚 **Rich API**: Search library, get item details, full-text search, annotations, and more

  ### Categories
  - `integration`: Integrates Zotero with external AI tools
  - `ai`: Enables AI-powered research workflows

  ### Links
  - [GitHub Repository](https://github.com/cookjohn/zotero-mcp)
  - [Latest Release](https://github.com/cookjohn/zotero-mcp/releases/latest)

  Thank you for considering this submission! 🙏