### PR TITLE
Add zotero2eagle plugin

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -988,6 +988,16 @@ export const plugins: PluginInfoBase[] = [
     tags: ['others'],
   },
   {
+    repo: 'yueneiqi/zotero2eagle',
+    releases: [
+      {
+        targetZoteroVersion: '7',
+        tagName: 'latest',
+      },
+    ],
+    tags: ['integration'],
+  },
+  {
     repo: 'zzlb0224/zotero-annotation-manage',
     releases: [
       {


### PR DESCRIPTION
## Summary
- Add yueneiqi/zotero2eagle plugin to the plugins list
- Plugin integrates Zotero with Eagle for managing PDF image annotations
- Supports Zotero 7 with latest releases
- Tagged as 'integration' category

## Description
This PR adds the zotero2eagle plugin which allows users to seamlessly save PDF image annotations from Zotero directly to their Eagle library for better visual content management.

Repository: https://github.com/yueneiqi/zotero2eagle

🤖 Generated with [Claude Code](https://claude.com/claude-code)