### PR TITLE
feat: update AI4Paper tags

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1572,7 +1572,7 @@ export const plugins: PluginInfoBase[] = [
         tagName: 'latest',
       },
     ],
-    tags: ['ai', 'productivity', 'reader', 'notes', 'metadata', 'writing', 'interface'],
+    tags: ['ai', 'productivity', 'reader', 'notes', 'metadata', 'interface', 'visualization'],
   },
   {
     repo: 'WildDataX/suppr-zotero-plugin',

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -627,7 +627,7 @@ export const plugins: PluginInfoBase[] = [
         tagName: 'latest',
       },
     ],
-    tags: ['ai', 'productivity', 'reader', 'notes', 'metadata', 'writing', 'interface'],
+    tags: ['ai', 'productivity'],
   },
   {
     repo: 'jagaldol/zotero-cite-preview-resizer',

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -627,7 +627,7 @@ export const plugins: PluginInfoBase[] = [
         tagName: 'latest',
       },
     ],
-    tags: ['ai', 'productivity'],
+    tags: ['ai', 'productivity', 'reader', 'notes', 'metadata', 'writing', 'interface'],
   },
   {
     repo: 'jagaldol/zotero-cite-preview-resizer',
@@ -1572,7 +1572,7 @@ export const plugins: PluginInfoBase[] = [
         tagName: 'latest',
       },
     ],
-    tags: ['ai', 'productivity'],
+    tags: ['ai', 'productivity', 'reader', 'notes', 'metadata', 'writing', 'interface'],
   },
   {
     repo: 'WildDataX/suppr-zotero-plugin',


### PR DESCRIPTION
## Summary

Update tags for AI4Paper plugin to better reflect its full feature coverage.

**Before:** `['ai', 'productivity']`
**After:** `['ai', 'productivity', 'reader', 'notes', 'metadata', 'writing', 'interface']`

AI4Paper covers:
- **reader** — PDF reader sidebar with translation, AI notes, mind map, AI chat
- **notes** — 10+ note types, note manager panel, batch export
- **metadata** — journal ranking (SCIE/SSCI/JCR/CAS), CNKI Chinese PDF recognition
- **writing** — 3 types of AI review (quick/standard/deep), literature matrix
- **interface** — custom columns, advanced filter bar, collection count, eye protection mode

Thank you for maintaining this great plugin directory! 🙏