### PR TITLE
feat: add Zotero 9 support for AI4Paper

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1579,6 +1579,10 @@ export const plugins: PluginInfoBase[] = [
         targetZoteroVersion: '8',
         tagName: 'latest',
       },
+      {
+        targetZoteroVersion: '9',
+        tagName: 'latest',
+      },
     ],
     tags: ['ai', 'productivity', 'reader', 'notes', 'metadata', 'interface', 'visualization'],
   },


### PR DESCRIPTION
## Summary

- Add `targetZoteroVersion: '9'` to AI4Paper plugin releases to support Zotero 9

## Changes

Added Zotero 9 release entry alongside existing Zotero 7 and 8 entries for `wdcpclover/ai4paper`.