### PR TITLE
zotero-grouptag

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -23,6 +23,16 @@ export const plugins: PluginInfoBase[] = [
     tags: ['integration'],
   },
   {
+    repo: "Ares960826/zotero-grouptag",
+    releases: [
+      {
+        targetZoteroVersion: "9",
+        tagName: "latest",
+      }
+    ],
+    tags: ['integration'],
+  },
+  {
     repo: '018/zotcard',
     releases: [
       {


### PR DESCRIPTION
Chrome-style visual tab grouping for the Zotero PDF reader —— Adds colored group headers and underline indicators to the Zotero tab bar, lets you create named groups, and manage tab assignments — all from a right-click context menu.

<img width="3840" height="442" alt="zotero_demo" src="https://github.com/user-attachments/assets/7c190b34-bef2-4489-8c99-9262c6495d3c" />
